### PR TITLE
SECURITY.md: add go-ports specific caution

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,3 +11,5 @@ part of that page.
 ## Reporting a Vulnerability
 
 See https://golang.org/security for how to report a vulnerability.
+
+(go-ports specific remark: Because of the time pressure and restricted visibility of security reports, please make extra clear in your communications if you are talking about a vulnerability that appears to be an issue in go-ports. Please always test first in upstream go, and if you can't or won't do so, realize that you may encounter annoyance rather than the normal gratitude for your report.)


### PR DESCRIPTION
Our motto in go-ports should be "first, do no harm" so let's go out of our way to be sure not to generate spurious trouble reports to the Go team.

Even better would be a dedicated go-ports security response, but only if it can be assured not to delay any reports that apply also to upstream. I don't know how we can do that yet.

This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
